### PR TITLE
Fix localstorage not available errors in test suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   bail: true,
   testMatch: [files],
   testEnvironment: process.env.TEST_ENV || 'jsdom',
+  testURL: 'http://localhost:8080/',
   automock: false,
   setupFiles: [
     "./test/setupJest.js"

--- a/test/unit/modules/browser-auto-tracking-spec.js
+++ b/test/unit/modules/browser-auto-tracking-spec.js
@@ -302,7 +302,7 @@ describe('Auto Tracking', () => {
     element: expect.any(Object),
     page: expect.any(Object),
     form: {
-      action: '/',
+      action: 'http://localhost:8080/',
       method: 'get',
       fields: {
         email: '---REDACTED---',
@@ -338,7 +338,7 @@ describe('Auto Tracking', () => {
     const pNode = document.createElement('INPUT');
 
     fNode.id = 'test-auto-tracker-submits';
-    fNode.action = '/';
+    fNode.action = 'http://localhost:8080/';
     fNode.onsubmit = mockFn1;
 
     iNode.type = 'text';


### PR DESCRIPTION
Getting this error locally:
> SecurityError: localStorage is not available for opaque origins

js-dom does not allow access to localStorage on the default page 'about:blank'

For details, see https://github.com/jsdom/jsdom/issues/2304#issuecomment-408320484